### PR TITLE
Add support for WinOnDeath condition

### DIFF
--- a/Patches/GS_ExpeditionSuccess.cs
+++ b/Patches/GS_ExpeditionSuccess.cs
@@ -12,7 +12,7 @@ namespace LocalProgression.Patches
             var CompletedExpedtionData = RundownManager.GetActiveExpeditionData();
 
             string expeditionKey = LocalProgressionManager.Current.ExpeditionKey(CompletedExpedtionData.tier, CompletedExpedtionData.expeditionIndex);
-            bool mainLayerCleared = WardenObjectiveManager.CurrentState.main_status == eWardenObjectiveStatus.WardenObjectiveItemSolved;
+            bool mainLayerCleared = WardenObjectiveManager.CurrentState.main_status == eWardenObjectiveStatus.WardenObjectiveItemSolved || WardenObjectiveManager.GetWinOnDeath();
             bool secondaryLayerCleared = WardenObjectiveManager.CurrentState.second_status == eWardenObjectiveStatus.WardenObjectiveItemSolved;
             bool thirdLayerCleared = WardenObjectiveManager.CurrentState.third_status == eWardenObjectiveStatus.WardenObjectiveItemSolved;
             bool clearedWithNoBooster = LocalProgressionManager.Current.AllSectorCompletedWithoutBoosterAndCheckpoint();


### PR DESCRIPTION
Currently if you create a level like R8E1, fire a WinOnDeath warden event `Type = 26` and then win the level by having the team go down: you'll see the success screen but the level won't be marked as completed in LocalProgression.

It seems to be because when completing a level like this, the game doesn't mark the main objective status as solved but it does provide a `GetWinOnDeath()` method which flags that the level is completed.

This PR just includes checking `GetWinOnDeath()` to determine if the main layer was cleared.